### PR TITLE
feat: fetcher 빈등록 및 collector 연결

### DIFF
--- a/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiAutoCollector.kt
+++ b/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiAutoCollector.kt
@@ -2,10 +2,12 @@ import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 
 class OpenApiAutoCollector(
+    private val fetcher: OpenApiFetcher,
     private val props: OpenApiDocsProperties
 ) : ApplicationRunner {
 
     override fun run(args: ApplicationArguments?) {
+        fetcher.fetch("Something todo");
         println("Todo: args")
     }
 }

--- a/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFetcher.kt
+++ b/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFetcher.kt
@@ -1,0 +1,5 @@
+class OpenApiFetcher() {
+    fun fetch(endpoint: String): String {
+        return ""
+    }
+}

--- a/openapi-starter/src/main/kotlin/io/github/openapidocstoolkit/starter/OpenApiDocsAutoConfiguration.kt
+++ b/openapi-starter/src/main/kotlin/io/github/openapidocstoolkit/starter/OpenApiDocsAutoConfiguration.kt
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 @EnableConfigurationProperties(OpenApiDocsProperties::class)
-@ConditionalOnProperty(prefix = "openapi-dos", name = ["enabled"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "openapi-docs", name = ["enabled"], havingValue = "true", matchIfMissing = true)
 class OpenApiDocsAutoConfiguration {
     @Bean
     fun openApiAutoCollector(fetcher: OpenApiFetcher, props: OpenApiDocsProperties): OpenApiAutoCollector{

--- a/openapi-starter/src/main/kotlin/io/github/openapidocstoolkit/starter/OpenApiDocsAutoConfiguration.kt
+++ b/openapi-starter/src/main/kotlin/io/github/openapidocstoolkit/starter/OpenApiDocsAutoConfiguration.kt
@@ -8,7 +8,11 @@ import org.springframework.context.annotation.Configuration
 @ConditionalOnProperty(prefix = "openapi-dos", name = ["enabled"], havingValue = "true", matchIfMissing = true)
 class OpenApiDocsAutoConfiguration {
     @Bean
-    fun openApiAutoCollector(props: OpenApiDocsProperties): OpenApiAutoCollector{
-        return OpenApiAutoCollector(props)
+    fun openApiAutoCollector(fetcher: OpenApiFetcher, props: OpenApiDocsProperties): OpenApiAutoCollector{
+        return OpenApiAutoCollector(fetcher, props)
+    }
+    @Bean
+    fun openApiFetcher(): OpenApiFetcher {
+        return OpenApiFetcher()
     }
 }


### PR DESCRIPTION
1. OpenApiFetcher bean 등록
2. OpenApiAutoCollector 내, OpenApiFetcher.fetch() 호출 등록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new component to handle OpenAPI fetching operations.
  - Enhanced configuration options to support the new fetching capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->