### PR TITLE
feat: OpenApiFetcher 내, OKHttpClient 사용하여 전달받은 endPoint GET 요청 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/test/**/build/
 
 ### IntelliJ IDEA ###
+.idea
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml

--- a/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFetcher.kt
+++ b/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFetcher.kt
@@ -1,5 +1,43 @@
-class OpenApiFetcher() {
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.time.Duration
+
+class OpenApiFetcher {
+
+    // OkHttpClient는 한 번만 생성해서 재사용
+    private val client = OkHttpClient.Builder()
+        .callTimeout(Duration.ofSeconds(5))
+        .connectTimeout(Duration.ofSeconds(3))
+        .build()
+
     fun fetch(endpoint: String): String {
-        return ""
+        //GET 요청
+        val request = Request.Builder()
+            .url(endpoint)
+            .get()
+            .build()
+
+        try {
+            client.newCall(request).execute().use { response ->
+                // sonarQube 요청으로 수정 - 가독성 및 중복성의 오류가 있을 수 있으며, kotlin 함수가 있다면 사용하는 것이 좋음
+                // require 내부적으로, 예외 발생시 IllegalStateException 발생
+                /*if (!response.isSuccessful) {
+                    throw IllegalStateException("OpenAPI fetch failed with code ${response.code} from $endpoint")
+                }*/
+                require(response.isSuccessful) { "OpenAPI fetch failed with code ${response.code} from $endpoint" }
+
+                // 결과값 체크
+                // sonarQube 요청으로 수정 - 가독성 및 중복성의 오류가 있을 수 있으며, kotlin 함수가 있다면 사용하는 것이 좋음
+                // requireNotNull 내부적으로 IllegalStateException 를 발생하지 않지만 가시성 향상을 위해 사용
+                /*val body = response.body?.string()
+                    ?: throw IllegalStateException("OpenAPI response body is null from $endpoint")*/
+                val body = requireNotNull(response.body?.string()) { "OpenAPI response body is null from $endpoint" }
+
+                return body
+            }
+        } catch (e: IOException) {
+            throw RuntimeException("Failed to fetch OpenAPI docs from $endpoint", e)
+        }
     }
 }


### PR DESCRIPTION
1. OKHttpClient 를 사용해서 GET 요청 기능 구현
2. if 분기에서, Kotlin 내부에서 사용한 require(), requireNotNull() 를 사용하여 가독성 up (SonarQube 플러그인이 캐치하여 준 사항)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - OpenApiFetcher가 이제 실제 HTTP 요청을 통해 엔드포인트에서 데이터를 정상적으로 가져오도록 동작이 개선되었습니다.

- **기타**
  - IntelliJ IDEA 프로젝트 폴더 전체가 버전 관리에서 제외되어 개발 환경 관련 파일이 저장소에 포함되지 않도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->