### PR TITLE
feat: OpenApiFileWriter 구현

### DIFF
--- a/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiAutoCollector.kt
+++ b/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiAutoCollector.kt
@@ -9,9 +9,24 @@ class OpenApiAutoCollector(
 ) : ApplicationRunner {
 
     override fun run(args: ApplicationArguments?) {
-        for (version in props.versions) {
-            val json = fetcher.fetch(props.endpoint)
-            fileWriter.write(json, version, props.outputDir)
+
+        if(props.versions.isEmpty()) {
+            println("[OPENAPI-DOCS-TOOLKIT] [WARNING] 처리할 버전이 없습니다.")
+            return
         }
+
+        for (version in props.versions) {
+            try {
+                println("[OPENAPI-DOCS-TOOLKIT] [INFO] '$version' 버전의 OpenAPI 문서를 처리합니다...")
+                val json = fetcher.fetch(props.endpoint)
+                fileWriter.write(json, version, props.outputDir)
+            } catch (e: Exception) {
+                println("[OPENAPI-DOCS-TOOLKIT] [ERROR] '$version' 버전 처리 중 오류 발생: ${e.message}")
+                // 로그에 스택 트레이스 출력
+                e.printStackTrace()
+            }
+        }
+
+        println("[OPENAPI-DOCS-TOOLKIT] [INFO] 모든 버전 처리 완료")
     }
 }

--- a/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiAutoCollector.kt
+++ b/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiAutoCollector.kt
@@ -1,13 +1,17 @@
+import io.github.openapidocstoolkit.core.OpenApiFileWriter
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 
 class OpenApiAutoCollector(
     private val fetcher: OpenApiFetcher,
+    private val fileWriter: OpenApiFileWriter,
     private val props: OpenApiDocsProperties
 ) : ApplicationRunner {
 
     override fun run(args: ApplicationArguments?) {
-        fetcher.fetch("Something todo");
-        println("Todo: args")
+        for (version in props.versions) {
+            val json = fetcher.fetch(props.endpoint)
+            fileWriter.write(json, version, props.outputDir)
+        }
     }
 }

--- a/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFetcher.kt
+++ b/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFetcher.kt
@@ -25,14 +25,14 @@ class OpenApiFetcher {
                 /*if (!response.isSuccessful) {
                     throw IllegalStateException("OpenAPI fetch failed with code ${response.code} from $endpoint")
                 }*/
-                require(response.isSuccessful) { "OpenAPI fetch failed with code ${response.code} from $endpoint" }
+                require(response.isSuccessful) { "OpenAPI 문서를 가져오는데 실패했습니다. 응답 코드:  ${response.code}, 엔드포인트: $endpoint" }
 
                 // 결과값 체크
                 // sonarQube 요청으로 수정 - 가독성 및 중복성의 오류가 있을 수 있으며, kotlin 함수가 있다면 사용하는 것이 좋음
                 // requireNotNull 내부적으로 IllegalStateException 를 발생하지 않지만 가시성 향상을 위해 사용
                 /*val body = response.body?.string()
                     ?: throw IllegalStateException("OpenAPI response body is null from $endpoint")*/
-                val body = requireNotNull(response.body?.string()) { "OpenAPI response body is null from $endpoint" }
+                val body = requireNotNull(response.body?.string()) { "OpenAPI 응답 본문이 비어있습니다. 엔드포인트: $endpoint" }
 
                 return body
             }

--- a/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFileWriter.kt
+++ b/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFileWriter.kt
@@ -5,6 +5,13 @@ import java.io.*
 class OpenApiFileWriter {
 
     fun write(json:String, version: String, outputDir: String) {
+
+        //버전 매개변수 검증 추가
+        //고민할 점, 경로 구분 없이 늘리고 싶은 경우는 어떻게 해야할지
+        require(!version.contains("..") && !version.contains("/") && !version.contains("\\")) {
+            "버전에 경로 구분자나 상위 디렉토리 참조가 포함도리 수 없습니다: $version"
+        }
+
         // 저장 디렉토리 경로: docs/v1 (예시)
         val versionDir = File(outputDir, version)
 
@@ -12,7 +19,7 @@ class OpenApiFileWriter {
         if(!versionDir.exists()) {
             val created = versionDir.mkdirs()
             if(!created) {
-                throw Exception("디렉토리 생성 실패: ${versionDir.absolutePath}")
+                throw IOException("디렉토리 생성 실패: ${versionDir.absolutePath}")
             }
         }
 
@@ -20,7 +27,11 @@ class OpenApiFileWriter {
         val outputFile = File(versionDir, "openapi.json")
 
         // 파일 저장
-        outputFile.writeText(json)
+        try {
+            outputFile.writeText(json)
+        } catch (e: IOException) {
+            throw IOException("[OPENAPI-DOCS-TOOLKIT] [ERROR] JSON 파일 저장 실패: ${outputFile.absolutePath}", e)
+        }
 
         // 성공 여부 확인
         println("[OPENAPI-DOCS-TOOLKIT] [INFO] OpenApi-Docs-toolkit 저장 완료: ${versionDir.absolutePath}")

--- a/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFileWriter.kt
+++ b/openapi-core/src/main/kotlin/io/github/openapidocstoolkit/core/OpenApiFileWriter.kt
@@ -1,0 +1,28 @@
+package io.github.openapidocstoolkit.core
+
+import java.io.*
+
+class OpenApiFileWriter {
+
+    fun write(json:String, version: String, outputDir: String) {
+        // 저장 디렉토리 경로: docs/v1 (예시)
+        val versionDir = File(outputDir, version)
+
+        // 디렉토리가 없다면 생성
+        if(!versionDir.exists()) {
+            val created = versionDir.mkdirs()
+            if(!created) {
+                throw Exception("디렉토리 생성 실패: ${versionDir.absolutePath}")
+            }
+        }
+
+        // 파일 경로: docs/v1/openapi.json
+        val outputFile = File(versionDir, "openapi.json")
+
+        // 파일 저장
+        outputFile.writeText(json)
+
+        // 성공 여부 확인
+        println("[OPENAPI-DOCS-TOOLKIT] [INFO] OpenApi-Docs-toolkit 저장 완료: ${versionDir.absolutePath}")
+    }
+}

--- a/openapi-starter/src/main/kotlin/io/github/openapidocstoolkit/starter/OpenApiDocsAutoConfiguration.kt
+++ b/openapi-starter/src/main/kotlin/io/github/openapidocstoolkit/starter/OpenApiDocsAutoConfiguration.kt
@@ -1,3 +1,4 @@
+import io.github.openapidocstoolkit.core.OpenApiFileWriter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -8,11 +9,16 @@ import org.springframework.context.annotation.Configuration
 @ConditionalOnProperty(prefix = "openapi-docs", name = ["enabled"], havingValue = "true", matchIfMissing = true)
 class OpenApiDocsAutoConfiguration {
     @Bean
-    fun openApiAutoCollector(fetcher: OpenApiFetcher, props: OpenApiDocsProperties): OpenApiAutoCollector{
-        return OpenApiAutoCollector(fetcher, props)
+    fun openApiAutoCollector(fetcher: OpenApiFetcher, fileWriter: OpenApiFileWriter, props: OpenApiDocsProperties): OpenApiAutoCollector{
+        return OpenApiAutoCollector(fetcher, fileWriter, props)
     }
     @Bean
     fun openApiFetcher(): OpenApiFetcher {
         return OpenApiFetcher()
+    }
+
+    @Bean
+    fun openApiWriter(): OpenApiFileWriter {
+        return OpenApiFileWriter()
     }
 }


### PR DESCRIPTION
1. openApiFileWriter 구현
2. 버전 별로 읽고 쓸 수 있도록 OpenApiAutoCollector 수정
3. OpenApiFetcher 내, 로그 내용 한글로 번역 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 여러 버전에 대해 OpenAPI 문서를 자동으로 가져와 버전별로 파일로 저장하는 기능이 추가되었습니다.
  - OpenAPI 문서가 각 버전별 디렉터리에 저장되며, 저장 완료 시 안내 메시지가 출력됩니다.
- **스타일**
  - OpenAPI 문서 관련 오류 메시지가 한글로 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->